### PR TITLE
Begin using Scaladoc groups

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,6 @@ lazy val baseSettings = Seq(
     }
   ),
   libraryDependencies ++= Seq(
-    compilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3"),
     compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
   ) ++ testDependencies.map(_ % "test"),
   resolvers += Resolver.sonatypeRepo("snapshots")
@@ -52,6 +51,7 @@ lazy val allSettings = buildSettings ++ baseSettings ++ unidocSettings ++ publis
 
 lazy val docSettings = site.settings ++ ghpages.settings ++ unidocSettings ++ Seq(
   site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "api"),
+  scalacOptions in (ScalaUnidoc, unidoc) := Seq("-groups", "-implicits"),
   git.remoteRepo := "git@github.com:travisbrown/jfc.git",
   unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(benchmark)
 )

--- a/core/src/main/scala/io/jfc/Cursor.scala
+++ b/core/src/main/scala/io/jfc/Cursor.scala
@@ -13,6 +13,10 @@ import io.jfc.cursor.{ CArray, CJson, CObject, CursorOperations }
  * with `withFocus` or changed using the navigation methods `left`, `right`,
  * etc.
  *
+ * @groupname Ungrouped Cursor fields and operations
+ * @groupprio Ungrouped 1
+ *
+ * @see [[GenericCursor]]
  * @author Travis Brown
  */
 abstract class Cursor extends CursorOperations {

--- a/core/src/main/scala/io/jfc/Encode.scala
+++ b/core/src/main/scala/io/jfc/Encode.scala
@@ -25,25 +25,62 @@ trait Encode[A] {
 /**
  * Utilities and instances for [[Encode]].
  *
+ * @groupname Utilities Miscellaneous utilities
+ * @groupprio Utilities 0
+ *
+ * @groupname Encode Encode instances
+ * @groupprio Encode 2
+ *
+ * @groupname Disjunction Disjunction instances
+ * @groupdesc Disjunction Instance creation methods for disjunction-like types.
+ * Note that these are implicit, since they require non-obvious decisions about
+ * the names of the discriminators. If you want instances for these types you
+ * can include the following import in your program:
+ * {{{
+ *    import io.jfc.disjunctionCodecs._
+ * }}}
+ * @groupprio Disjunction 8
+ *
+ * @groupname Instances Type class instances
+ * @groupprio Instances 10
+ *
  * @author Travis Brown
  */
 object Encode {
   /**
    * Return an instance for a given type.
+   *
+   * @group Utilities
    */
   def apply[A](implicit e: Encode[A]): Encode[A] = e
 
-  implicit def fromCodec[A](implicit c: Codec[A]): Encode[A] = c.encoder
-
+  /**
+   * Construct an instance from a function.
+   *
+   * @group Utilities
+   */
   def instance[A](f: A => Json): Encode[A] = new Encode[A] {
     def apply(a: A): Json = f(a)
   }
 
+  /**
+   * Construct an instance for a given type with a [[cats.Foldable]] instance.
+   *
+   * @group Utilities
+   */
   def fromFoldable[F[_], A](implicit e: Encode[A], F: Foldable[F]): Encode[F[A]] =
     instance(fa =>
       Json.array(F.foldLeft(fa, Nil: List[Json])((list, a) => e(a) :: list).reverse: _*)
     )
 
+  /**
+   * @group Encode
+   */
+  implicit def fromCodec[A](implicit c: Codec[A]): Encode[A] = c.encoder
+
+  /**
+   * @group Encode
+   */
   implicit def encodeTraversableOnce[A0, C[_]](implicit
     e: Encode[A0],
     is: collection.generic.IsTraversableOnce[C[A0]] { type A = A0 }
@@ -58,31 +95,81 @@ object Encode {
     Json.fromValues(items)
   }
 
+  /**
+   * @group Encode
+   */
   implicit val encodeJson: Encode[Json] = instance(identity)
+
+  /**
+   * @group Encode
+   */
   implicit val encodeString: Encode[String] = instance(Json.string)
 
+  /**
+   * @group Encode
+   */
   implicit val encodeUnit: Encode[Unit] = instance(_ => Json.obj())
 
+  /**
+   * @group Encode
+   */
   implicit val encodeBoolean: Encode[Boolean] = instance(Json.bool)
+
+  /**
+   * @group Encode
+   */
   implicit val encodeChar: Encode[Char] = instance(a => Json.string(a.toString))
 
+  /**
+   * @group Encode
+   */
   implicit val encodeFloat: Encode[Float] = instance(a => JsonDouble(a.toDouble).asJsonOrNull)
+
+  /**
+   * @group Encode
+   */
   implicit val encodeDouble: Encode[Double] = instance(a => JsonDouble(a).asJsonOrNull)
 
+  /**
+   * @group Encode
+   */
   implicit val encodeByte: Encode[Byte] = instance(a => JsonLong(a.toLong).asJsonOrNull)
+
+  /**
+   * @group Encode
+   */
   implicit val encodeShort: Encode[Short] = instance(a => JsonLong(a.toLong).asJsonOrNull)
+
+  /**
+   * @group Encode
+   */
   implicit val encodeInt: Encode[Int] = instance(a => JsonLong(a.toLong).asJsonOrNull)
+
+  /**
+   * @group Encode
+   */
   implicit val encodeLong: Encode[Long] = instance(a => JsonLong(a).asJsonOrNull)
 
+  /**
+   * @group Encode
+   */
   implicit val encodeBigInt: Encode[BigInt] =
     instance(a => JsonBigDecimal(BigDecimal(a, java.math.MathContext.UNLIMITED)).asJsonOrNull)
 
+  /**
+   * @group Encode
+   */
   implicit val encodeBigDecimal: Encode[BigDecimal] = instance(a => JsonBigDecimal(a).asJsonOrNull)
 
+  /**
+   * @group Encode
+   */
   implicit def encodeOption[A](implicit e: Encode[A]): Encode[Option[A]] =
     instance(_.fold(Json.empty)(e(_)))
 
-
+  /**
+   * @group Encode
+   */
   implicit def encodeMapLike[M[K, +V] <: Map[K, V], V](implicit
     e: Encode[V]
   ): Encode[M[String, V]] = instance(m =>
@@ -93,10 +180,15 @@ object Encode {
     )
   )
 
+  /**
+   * @group Encode
+   */
   implicit def encodeNonEmptyList[A: Encode]: Encode[NonEmptyList[A]] =
     fromFoldable[NonEmptyList, A]
 
-
+  /**
+   * @group Disjunction
+   */
   def encodeXor[A, B](leftKey: String, rightKey: String)(implicit
     ea: Encode[A],
     eb: Encode[B]
@@ -107,16 +199,25 @@ object Encode {
     )
   )
 
+  /**
+   * @group Disjunction
+   */
   def encodeEither[A, B](leftKey: String, rightKey: String)(implicit
     ea: Encode[A],
     eb: Encode[B]
   ): Encode[Either[A, B]] = encodeXor[A, B](leftKey, rightKey).contramap(Xor.fromEither)
 
+  /**
+   * @group Disjunction
+   */
   def encodeValidated[E, A](failureKey: String, successKey: String)(implicit
     ee: Encode[E],
     ea: Encode[A]
   ): Encode[Validated[E, A]] = encodeXor[E, A](failureKey, successKey).contramap(_.toXor)
 
+  /**
+   * @group Instances
+   */
   implicit val contravariantEncode: Contravariant[Encode] = new Contravariant[Encode] {
     def contramap[A, B](e: Encode[A])(f: B => A): Encode[B] = e.contramap(f)
   }

--- a/core/src/main/scala/io/jfc/GenericCursor.scala
+++ b/core/src/main/scala/io/jfc/GenericCursor.scala
@@ -24,197 +24,309 @@ import cats.data.Xor
  * navigation and modification operations, and `M` is a type class that includes
  * the operations that we need for `withFocusM`.
  *
+ * @groupname TypeMembers Type members
+ * @groupprio TypeMembers 0
+ * @groupname Access Access and navigation
+ * @groupprio Access 2
+ * @groupname Modification Modification
+ * @groupprio Modification 3
+ * @groupname ArrayAccess Array access
+ * @groupprio ArrayAccess 4
+ * @groupname ObjectAccess Object access
+ * @groupprio ObjectAccess 5
+ * @groupname ArrayNavigation Array navigation
+ * @groupprio ArrayNavigation 6
+ * @groupname ObjectNavigation Object navigation
+ * @groupprio ObjectNavigation 7
+ * @groupname ArrayModification Array modification
+ * @groupprio ArrayModification 8
+ * @groupname ObjectModification Object modification
+ * @groupprio ObjectModification 9
+ * @groupname Decoding Decoding
+ * @groupprio Decoding 10
+ *
  * @author Travis Brown
  */
 trait GenericCursor[C <: GenericCursor[C]] {
+  /**
+   * The context that the cursor is available in.
+   *
+   * @group TypeMembers
+   */
   type Focus[_]
+
+  /**
+   * The type returned by navigation and modifications operations.
+   *
+   * @group TypeMembers
+   */
   type Result
+
+  /**
+   * The type class including the operations needed for `withFocusM`.
+   *
+   * @group TypeMembers
+   */
   type M[_[_]]
 
   /**
    * The current location in the document.
+   *
+   * @group Access
    */
   def focus: Focus[Json]
 
   /**
    * Return to the root of the document.
+   *
+   * @group Access
    */
   def undo: Focus[Json]
 
   /**
-   * Attempt to decode the focus as an `A`.
+   * Move the focus to the parent.
+   *
+   * @group Access
    */
-  def as[A](implicit decode: Decode[A]): Xor[DecodeFailure, A]
+  def up: Result
 
   /**
-   * Attempt to decode the value at the given key in a JSON object as an `A`.
+   * Delete the focus and move to its parent.
+   *
+   * @group Modification
    */
-  def get[A](k: String)(implicit decode: Decode[A]): Xor[DecodeFailure, A]
+  def delete: Result
 
   /**
    * Modify the focus using the given function.
+   *
+   * @group Modification
    */
   def withFocus(f: Json => Json): C
 
   /**
    * Modify the focus in a context using the given function.
+   *
+   * @group Modification
    */
   def withFocusM[F[_]: M](f: Json => F[Json]): F[C]
 
   /**
    * Replace the focus.
+   *
+   * @group Modification
    */
   def set(j: Json): C = withFocus(_ => j)
 
   /**
    * If the focus is a JSON array, return the elements to the left.
+   *
+   * @group ArrayAccess
    */
   def lefts: Option[List[Json]]
 
   /**
    * If the focus is a JSON array, return the elements to the right.
+   *
+   * @group ArrayAccess
    */
   def rights: Option[List[Json]]
 
   /**
    * If the focus is a JSON object, return its field names in a set.
+   *
+   * @group ObjectAccess
    */
   def fieldSet: Option[Set[String]]
 
   /**
    * If the focus is a JSON object, return its field names in their original
    * order.
+   *
+   * @group ObjectAccess
    */
   def fields: Option[List[String]]
 
   /**
    * If the focus is an element in a JSON array, move to the left.
+   *
+   * @group ArrayNavigation
    */
   def left: Result
 
   /**
    * If the focus is an element in a JSON array, move to the right.
+   *
+   * @group ArrayNavigation
    */
   def right: Result
 
   /**
    * If the focus is an element in a JSON array, move to the first element.
+   *
+   * @group ArrayNavigation
    */
   def first: Result
 
   /**
    * If the focus is an element in a JSON array, move to the last element.
+   *
+   * @group ArrayNavigation
    */
   def last: Result
 
   /**
    * If the focus is an element in JSON array, move to the left the given number
    * of times. A negative value will move the cursor right.
+   *
+   * @group ArrayNavigation
    */
   def leftN(n: Int): Result
 
   /**
    * If the focus is an element in JSON array, move to the right the given
    * number of times. A negative value will move the cursor left.
+   *
+   * @group ArrayNavigation
    */
   def rightN(n: Int): Result
 
   /**
    * If the focus is an element in a JSON array, move to the left until the
    * given predicate matches the new focus.
+   *
+   * @group ArrayNavigation
    */
   def leftAt(p: Json => Boolean): Result
 
   /**
    * If the focus is an element in a JSON array, move to the right until the
    * given predicate matches the new focus.
+   *
+   * @group ArrayNavigation
    */
   def rightAt(p: Json => Boolean): Result
 
   /**
    * If the focus is an element in a JSON array, find the first element at or to
    * its right that matches the given predicate.
+   *
+   * @group ArrayNavigation
    */
   def find(p: Json => Boolean): Result
 
   /**
-   * If the focus is a value in a JSON object, move to a sibling with the given
-   * key.
-   */
-  def field(k: String): Result
-
-  /**
-   * If the focus is a JSON object, move to the value of the given key.
-   */
-  def downField(k: String): Result
-
-  /**
    * If the focus is a JSON array, move to its first element.
+   *
+   * @group ArrayNavigation
    */
   def downArray: Result
 
   /**
    * If the focus is a JSON array, move to the first element that satisfies the
    * given predicate.
+   *
+   * @group ArrayNavigation
    */
   def downAt(p: Json => Boolean): Result
 
   /**
    * If the focus is a JSON array, move to the element at the given index.
+   *
+   * @group ArrayNavigation
    */
   def downN(n: Int): Result
 
   /**
-   * Delete the focus and move to its parent.
+   * If the focus is a value in a JSON object, move to a sibling with the given
+   * key.
+   *
+   * @group ObjectNavigation
    */
-  def delete: Result
+  def field(k: String): Result
+
+  /**
+   * If the focus is a JSON object, move to the value of the given key.
+   *
+   * @group ObjectNavigation
+   */
+  def downField(k: String): Result
 
   /**
    * Delete the focus and move to the left in a JSON array.
+   *
+   * @group ArrayModification
    */
   def deleteGoLeft: Result
 
   /**
    * Delete the focus and move to the right in a JSON array.
+   *
+   * @group ArrayModification
    */
   def deleteGoRight: Result
 
   /**
    * Delete the focus and move to the first element in a JSON array.
+   *
+   * @group ArrayModification
    */
   def deleteGoFirst: Result
 
   /**
    * Delete the focus and move to the last element in a JSON array.
+   *
+   * @group ArrayModification
    */
   def deleteGoLast: Result
 
   /**
-   * Delete the focus and move to the sibling with the given key in a JSON
-   * object.
-   */
-  def deleteGoField(k: String): Result
-
-  /**
    * Delete all values to the left of the focus in a JSON array.
+   *
+   * @group ArrayModification
    */
   def deleteLefts: Result
 
   /**
    * Delete all values to the right of the focus in a JSON array.
+   *
+   * @group ArrayModification
    */
   def deleteRights: Result
 
   /**
    * Replace all values to the left of the focus in a JSON array.
+   *
+   * @group ArrayModification
    */
   def setLefts(x: List[Json]): Result
 
   /**
    * Replace all values to the right of the focus in a JSON array.
+   *
+   * @group ArrayModification
    */
   def setRights(x: List[Json]): Result
 
-  /** Move the focus to the parent. */
-  def up: Result
+  /**
+   * Delete the focus and move to the sibling with the given key in a JSON
+   * object.
+   *
+   * @group ObjectModification
+   */
+  def deleteGoField(k: String): Result
+
+  /**
+   * Attempt to decode the focus as an `A`.
+   *
+   * @group Decoding
+   */
+  def as[A](implicit decode: Decode[A]): Xor[DecodeFailure, A]
+
+  /**
+   * Attempt to decode the value at the given key in a JSON object as an `A`.
+   *
+   * @group Decoding
+   */
+  def get[A](k: String)(implicit decode: Decode[A]): Xor[DecodeFailure, A]
 }

--- a/core/src/main/scala/io/jfc/HCursor.scala
+++ b/core/src/main/scala/io/jfc/HCursor.scala
@@ -4,6 +4,15 @@ import algebra.Eq
 import cats.data.Xor
 import io.jfc.cursor.HCursorOperations
 
+/**
+ * A cursor that tracks the history of operations performed with it.
+ *
+ * @groupname Ungrouped HCursor fields and operations
+ * @groupprio Ungrouped 1
+ *
+ * @see [[GenericCursor]]
+ * @author Travis Brown
+ */
 case class HCursor(cursor: Cursor, history: CursorHistory) extends HCursorOperations {
   /**
    * Create an [[ACursor]] for this cursor.

--- a/core/src/main/scala/io/jfc/cursor/ACursorOperations.scala
+++ b/core/src/main/scala/io/jfc/cursor/ACursorOperations.scala
@@ -21,14 +21,22 @@ private[jfc] trait ACursorOperations extends GenericCursor[ACursor] { this: ACur
 
   def focus: Option[Json] = success.map(_.focus)
   def undo: Option[Json] = success.map(_.undo)
-  def as[A](implicit decode: Decode[A]): Xor[DecodeFailure, A] = decode.tryDecode(this)
-  def get[A](k: String)(implicit decode: Decode[A]): Xor[DecodeFailure, A] = downField(k).as[A]
+  def up: ACursor = withHCursor(_.up)
+
+  def delete: ACursor = withHCursor(_.delete)
   def withFocus(f: Json => Json): ACursor = ACursor(either.map(_.withFocus(f)))
   def withFocusM[F[_]](f: Json => F[Json])(implicit F: Applicative[F]): F[ACursor] =
     either.fold(
       _ => F.pure(this),
       valid => F.map(valid.withFocusM(f))(ACursor.ok)
     )
+
+  def lefts: Option[List[Json]] = success.flatMap(_.lefts)
+  def rights: Option[List[Json]] = success.flatMap(_.rights)
+
+  def fieldSet: Option[Set[String]] = success.flatMap(_.fieldSet)
+  def fields: Option[List[String]] = success.flatMap(_.fields)
+
   def left: ACursor = withHCursor(_.left)
   def right: ACursor = withHCursor(_.right)
   def first: ACursor = withHCursor(_.first)
@@ -38,20 +46,24 @@ private[jfc] trait ACursorOperations extends GenericCursor[ACursor] { this: ACur
   def leftAt(p: Json => Boolean): ACursor = withHCursor(_.leftAt(p))
   def rightAt(p: Json => Boolean): ACursor = withHCursor(_.rightAt(p))
   def find(p: Json => Boolean): ACursor = withHCursor(_.find(p))
-  def field(k: String): ACursor = withHCursor(_.field(k))
-  def downField(k: String): ACursor = withHCursor(_.downField(k))
   def downArray: ACursor = withHCursor(_.downArray)
   def downAt(p: Json => Boolean): ACursor = withHCursor(_.downAt(p))
   def downN(n: Int): ACursor = withHCursor(_.downN(n))
-  def delete: ACursor = withHCursor(_.delete)
+
+  def field(k: String): ACursor = withHCursor(_.field(k))
+  def downField(k: String): ACursor = withHCursor(_.downField(k))
+
   def deleteGoLeft: ACursor = withHCursor(_.deleteGoLeft)
   def deleteGoRight: ACursor = withHCursor(_.deleteGoRight)
   def deleteGoFirst: ACursor = withHCursor(_.deleteGoFirst)
   def deleteGoLast: ACursor = withHCursor(_.deleteGoLast)
-  def deleteGoField(k: String): ACursor = withHCursor(_.deleteGoField(k))
   def deleteLefts: ACursor = withHCursor(_.deleteLefts)
   def deleteRights: ACursor = withHCursor(_.deleteRights)
   def setLefts(x: List[Json]): ACursor = withHCursor(_.setLefts(x))
   def setRights(x: List[Json]): ACursor = withHCursor(_.setRights(x))
-  def up: ACursor = withHCursor(_.up)
+
+  def deleteGoField(k: String): ACursor = withHCursor(_.deleteGoField(k))
+
+  def as[A](implicit decode: Decode[A]): Xor[DecodeFailure, A] = decode.tryDecode(this)
+  def get[A](k: String)(implicit decode: Decode[A]): Xor[DecodeFailure, A] = downField(k).as[A]
 }

--- a/core/src/main/scala/io/jfc/cursor/CJson.scala
+++ b/core/src/main/scala/io/jfc/cursor/CJson.scala
@@ -5,9 +5,9 @@ import io.jfc.{ Context, Cursor, Json }
 
 private[jfc] case class CJson(focus: Json) extends Cursor {
   def context: Context = Context.empty
+  def up: Option[Cursor] = None
+  def delete: Option[Cursor] = None
   def withFocus(f: Json => Json): Cursor = CJson(f(focus))
   def withFocusM[F[_]](f: Json => F[Json])(implicit F: Functor[F]): F[Cursor] =
     F.map(f(focus))(CJson.apply)
-  def delete: Option[Cursor] = None
-  def up: Option[Cursor] = None
 }

--- a/core/src/main/scala/io/jfc/cursor/CursorOperations.scala
+++ b/core/src/main/scala/io/jfc/cursor/CursorOperations.scala
@@ -13,12 +13,42 @@ private[jfc] trait CursorOperations extends GenericCursor[Cursor] { this: Cursor
   type Result = Option[Cursor]
   type M[x[_]] = Functor[x]
 
-  def as[A](implicit decode: Decode[A]): Xor[DecodeFailure, A] = hcursor.as[A]
-  def get[A](k: String)(implicit decode: Decode[A]): Xor[DecodeFailure, A] = hcursor.get[A](k)
+  def undo: Json = {
+    @tailrec
+    def go(c: Cursor): Json = c match {
+      case CJson(j) => j
+      case CArray(j, p, u, ls, rs) =>
+        val q = Json.fromValues(ls.reverse_:::(j :: rs))
+
+        go(
+          p match {
+            case CJson(_) => CJson(q)
+            case arr @ CArray(_, _, v, _, _) => arr.copy(focus = q, u = u || v)
+            case obj @ CObject(_, pk, _, v, po) =>
+              obj.copy(focus = q, u = u || v, o = if (u) po + (pk, q) else po)
+          }
+        )
+      case CObject(j, k, p, u, o) =>
+        val q = Json.fromJsonObject(if (u) o + (k, j) else o)
+
+        go(
+          p match {
+            case CJson(_) => CJson(q)
+            case arr @ CArray(_, _, v, _, _) => arr.copy(focus = q, u = u || v)
+            case obj @ CObject(_, pk, _, v, po) => obj.copy(focus = q, u = u || v)
+          }
+        )
+    }
+
+    go(this)
+  }
+
   def lefts: Option[List[Json]] = None
   def rights: Option[List[Json]] = None
+
   def fieldSet: Option[Set[String]] = focus.asObj.map(_.fieldSet)
   def fields: Option[List[String]] = focus.asObj.map(_.fields)
+
   def left: Option[Cursor] = None
   def right: Option[Cursor] = None
   def first: Option[Cursor] = None
@@ -62,11 +92,6 @@ private[jfc] trait CursorOperations extends GenericCursor[Cursor] { this: Cursor
     go(Some(this))
   }
 
-  def field(k: String): Option[Cursor] = None
-
-  def downField(k: String): Option[Cursor] =
-    focus.asObj.flatMap(o => o(k).map(j => CObject(j, k, this, false, o)))
-
   def downArray: Option[Cursor] = focus.asArray.flatMap {
     case h :: t => Some(CArray(h, this, false, Nil, t))
     case Nil => None
@@ -77,43 +102,22 @@ private[jfc] trait CursorOperations extends GenericCursor[Cursor] { this: Cursor
 
   def downN(n: Int): Option[Cursor] = downArray.flatMap(_.rightN(n))
 
+  def field(k: String): Option[Cursor] = None
+
+  def downField(k: String): Option[Cursor] =
+    focus.asObj.flatMap(o => o(k).map(j => CObject(j, k, this, false, o)))
+
   def deleteGoLeft: Option[Cursor] = None
   def deleteGoRight: Option[Cursor] = None
   def deleteGoFirst: Option[Cursor] = None
   def deleteGoLast: Option[Cursor] = None
-  def deleteGoField(q: String): Option[Cursor] = None
   def deleteLefts: Option[Cursor] = None
   def deleteRights: Option[Cursor] = None
   def setLefts(x: List[Json]): Option[Cursor] = None
   def setRights(x: List[Json]): Option[Cursor] = None
 
-  def undo: Json = {
-    @tailrec
-    def go(c: Cursor): Json = c match {
-      case CJson(j) => j
-      case CArray(j, p, u, ls, rs) =>
-        val q = Json.fromValues(ls.reverse_:::(j :: rs))
+  def deleteGoField(q: String): Option[Cursor] = None
 
-        go(
-          p match {
-            case CJson(_) => CJson(q)
-            case arr @ CArray(_, _, v, _, _) => arr.copy(focus = q, u = u || v)
-            case obj @ CObject(_, pk, _, v, po) =>
-              obj.copy(focus = q, u = u || v, o = if (u) po + (pk, q) else po)
-          }
-        )
-      case CObject(j, k, p, u, o) =>
-        val q = Json.fromJsonObject(if (u) o + (k, j) else o)
-
-        go(
-          p match {
-            case CJson(_) => CJson(q)
-            case arr @ CArray(_, _, v, _, _) => arr.copy(focus = q, u = u || v)
-            case obj @ CObject(_, pk, _, v, po) => obj.copy(focus = q, u = u || v)
-          }
-        )
-    }
-
-    go(this)
-  }
+  def as[A](implicit decode: Decode[A]): Xor[DecodeFailure, A] = hcursor.as[A]
+  def get[A](k: String)(implicit decode: Decode[A]): Xor[DecodeFailure, A] = hcursor.get[A](k)
 }

--- a/core/src/main/scala/io/jfc/cursor/HCursorOperations.scala
+++ b/core/src/main/scala/io/jfc/cursor/HCursorOperations.scala
@@ -15,19 +15,21 @@ private[jfc] trait HCursorOperations extends GenericCursor[HCursor] { this: HCur
 
   def focus: Json = cursor.focus
   def undo: Json = cursor.undo
-  def as[A](implicit decode: Decode[A]): Xor[DecodeFailure, A] = decode(this)
-  def get[A](k: String)(implicit decode: Decode[A]): Xor[DecodeFailure, A] = downField(k).as[A]
+  def up: ACursor = history.acursorElement(cursor, _.up, CursorOpUp)
+
+  def delete: ACursor = history.acursorElement(cursor, _.delete, CursorOpDeleteGoParent)
   def withFocus(f: Json => Json): HCursor = HCursor(cursor.withFocus(f), history)
   def withFocusM[F[_]: Functor](f: Json => F[Json]): F[HCursor] =
     Functor[F].map(cursor.withFocusM(f))(c => HCursor(c, history))
-  def lefts: Option[List[Json]] = cursor.lefts
-  def rights: Option[List[Json]] = cursor.rights
-  def fieldSet: Option[Set[String]] = cursor.fieldSet
-  def fields: Option[List[String]] = cursor.fields
+
   def left: ACursor = history.acursorElement(cursor, _.left, CursorOpLeft)
   def right: ACursor = history.acursorElement(cursor, _.right, CursorOpRight)
   def first: ACursor = history.acursorElement(cursor, _.left, CursorOpFirst)
   def last: ACursor = history.acursorElement(cursor, _.left, CursorOpLast)
+  def lefts: Option[List[Json]] = cursor.lefts
+  def rights: Option[List[Json]] = cursor.rights
+  def fieldSet: Option[Set[String]] = cursor.fieldSet
+  def fields: Option[List[String]] = cursor.fields
   def leftN(n: Int): ACursor = history.acursorElement(cursor, _.leftN(n), CursorOpLeftN(n))
   def rightN(n: Int): ACursor = history.acursorElement(cursor, _.rightN(n), CursorOpRightN(n))
   def leftAt(p: Json => Boolean): ACursor =
@@ -36,14 +38,14 @@ private[jfc] trait HCursorOperations extends GenericCursor[HCursor] { this: HCur
     history.acursorElement(cursor, _.rightAt(p), CursorOpRightAt(p))
   def find(p: Json => Boolean): ACursor =
     history.acursorElement(cursor, _.find(p), CursorOpRightAt(p))
-  def field(k: String): ACursor = history.acursorElement(cursor, _.field(k), CursorOpField(k))
-  def downField(k: String): ACursor =
-    history.acursorElement(cursor, _.downField(k), CursorOpDownField(k))
   def downArray: ACursor = history.acursorElement(cursor, _.downArray, CursorOpDownArray)
   def downAt(p: Json => Boolean): ACursor =
     history.acursorElement(cursor, _.downAt(p), CursorOpDownAt(p))
   def downN(n: Int): ACursor = history.acursorElement(cursor, _.downN(n), CursorOpDownN(n))
-  def delete: ACursor = history.acursorElement(cursor, _.delete, CursorOpDeleteGoParent)
+
+  def field(k: String): ACursor = history.acursorElement(cursor, _.field(k), CursorOpField(k))
+  def downField(k: String): ACursor =
+    history.acursorElement(cursor, _.downField(k), CursorOpDownField(k))
   def deleteGoLeft: ACursor = history.acursorElement(cursor, _.deleteGoLeft, CursorOpDeleteGoLeft)
   def deleteGoRight: ACursor =
     history.acursorElement(cursor, _.deleteGoRight, CursorOpDeleteGoRight)
@@ -51,13 +53,16 @@ private[jfc] trait HCursorOperations extends GenericCursor[HCursor] { this: HCur
     history.acursorElement(cursor, _.deleteGoFirst, CursorOpDeleteGoFirst)
   def deleteGoLast: ACursor =
     history.acursorElement(cursor, _.deleteGoLast, CursorOpDeleteGoLast)
-  def deleteGoField(k: String): ACursor =
-    history.acursorElement(cursor, _.deleteGoField(k), CursorOpDeleteGoField(k))
   def deleteLefts: ACursor = history.acursorElement(cursor, _.deleteLefts, CursorOpDeleteLefts)
   def deleteRights: ACursor = history.acursorElement(cursor, _.deleteRights, CursorOpDeleteRights)
   def setLefts(js: List[Json]): ACursor =
     history.acursorElement(cursor, _.setLefts(js), CursorOpDeleteRights)
   def setRights(js: List[Json]): ACursor =
     history.acursorElement(cursor, _.setRights(js), CursorOpDeleteRights)
-  def up: ACursor = history.acursorElement(cursor, _.up, CursorOpUp)
+
+  def deleteGoField(k: String): ACursor =
+    history.acursorElement(cursor, _.deleteGoField(k), CursorOpDeleteGoField(k))
+
+  def as[A](implicit decode: Decode[A]): Xor[DecodeFailure, A] = decode(this)
+  def get[A](k: String)(implicit decode: Decode[A]): Xor[DecodeFailure, A] = downField(k).as[A]
 }


### PR DESCRIPTION
This is just a start, but I find that grouping methods makes the API docs [much more useful](https://travisbrown.github.io/jfc/api/#io.jfc.Encode$).