### PR TITLE
New README section and some API changes and additions

### DIFF
--- a/auto/src/main/scala/io/jfc/auto/GenericEncode.scala
+++ b/auto/src/main/scala/io/jfc/auto/GenericEncode.scala
@@ -20,7 +20,7 @@ trait GenericEncode extends LowPriorityGenericEncode {
     Encode.instance {
       case h :: t =>
         val tailJson = encodeTail.value(t)
-        tailJson.asObj.fold(tailJson) { obj =>
+        tailJson.asObject.fold(tailJson) { obj =>
           Json.fromJsonObject((key.value.name -> encodeHead.value(h)) +: obj)
         }
     }

--- a/build.sbt
+++ b/build.sbt
@@ -61,6 +61,16 @@ lazy val root = project.in(file("."))
   .settings(docSettings)
   .settings(noPublish)
   .settings(scalacOptions in (Compile, console) := compilerOptions)
+  .settings(
+    initialCommands in console :=
+      """
+        |import io.jfc._
+        |import io.jfc.auto._
+        |import io.jfc.jawn._
+        |import io.jfc.syntax._
+        |import cats.data.Xor
+      """.stripMargin
+  )
   .aggregate(core, auto, jawn, async, benchmark)
   .dependsOn(core, auto, jawn, async)
 

--- a/core/src/main/scala/io/jfc/GenericCursor.scala
+++ b/core/src/main/scala/io/jfc/GenericCursor.scala
@@ -81,7 +81,7 @@ trait GenericCursor[C <: GenericCursor[C]] {
    *
    * @group Access
    */
-  def undo: Focus[Json]
+  def top: Focus[Json]
 
   /**
    * Move the focus to the parent.

--- a/core/src/main/scala/io/jfc/Json.scala
+++ b/core/src/main/scala/io/jfc/Json.scala
@@ -56,14 +56,34 @@ sealed abstract class Json extends Product with Serializable {
   def cursor: Cursor = Cursor(this)
 
   /**
-   * Returns the possible object of this JSON value.
+   * Construct a cursor with history from this JSON value.
    */
-  def asObj: Option[JsonObject] = None
-
-  def asArray: Option[List[Json]] = None
+  def hcursor: HCursor = Cursor(this).hcursor
 
   def isNull: Boolean = false
+  def isBoolean: Boolean = false
+  def isNumber: Boolean = false
+  def isString: Boolean = false
   def isArray: Boolean = false
+  def isObject: Boolean = false
+
+  def asBoolean: Option[Boolean] = None
+  def asNumber: Option[JsonNumber] = None
+  def asString: Option[String] = None
+  def asArray: Option[List[Json]] = None
+  def asObject: Option[JsonObject] = None
+
+  def withBoolean(f: Boolean => Json): Json = asBoolean.fold(this)(f)
+  def withNumber(f: JsonNumber => Json): Json = asNumber.fold(this)(f)
+  def withString(f: String => Json): Json = asString.fold(this)(f)
+  def withArray(f: List[Json] => Json): Json = asArray.fold(this)(f)
+  def withObject(f: JsonObject => Json): Json = asObject.fold(this)(f)
+
+  def mapBoolean(f: Boolean => Boolean): Json = this
+  def mapNumber(f: JsonNumber => JsonNumber): Json = this
+  def mapString(f: String => String): Json = this
+  def mapArray(f: List[Json] => List[Json]): Json = this
+  def mapObject(f: JsonObject => JsonObject): Json = this
 
   /**
    * The name of the type of the JSON value.
@@ -113,16 +133,31 @@ object Json {
   private[jfc] case object JNull extends Json {
     override def isNull: Boolean = true
   }
-  private[jfc] final case class JBool(b: Boolean) extends Json
-  private[jfc] final case class JString(s: String) extends Json
+  private[jfc] final case class JBool(b: Boolean) extends Json {
+    override def isBoolean: Boolean = true
+    override def asBoolean: Option[Boolean] = Some(b)
+    override def mapBoolean(f: Boolean => Boolean): Json = JBool(f(b))
+  }
+  private[jfc] final case class JNumber(n: JsonNumber) extends Json {
+    override def isNumber: Boolean = true
+    override def asNumber: Option[JsonNumber] = Some(n)
+    override def mapNumber(f: JsonNumber => JsonNumber): Json = JNumber(f(n))
+  }
+  private[jfc] final case class JString(s: String) extends Json {
+    override def isString: Boolean = true
+    override def asString: Option[String] = Some(s)
+    override def mapString(f: String => String): Json = JString(f(s))
+  }
   private[jfc] final case class JArray(a: Seq[Json]) extends Json {
     override def isArray: Boolean = true
     override def asArray: Option[List[Json]] = Some(a.toList)
+    override def mapArray(f: List[Json] => List[Json]): Json = JArray(f(a.toList))
   }
   private[jfc] final case class JObject(o: JsonObject) extends Json {
-    override def asObj: Option[JsonObject] = Some(o)
+    override def isObject: Boolean = true
+    override def asObject: Option[JsonObject] = Some(o)
+    override def mapObject(f: JsonObject => JsonObject): Json = JObject(f(o))
   }
-  private[jfc] final case class JNumber(n: JsonNumber) extends Json
 
   val empty: Json = JNull
   def bool(b: Boolean): Json = JBool(b)

--- a/core/src/main/scala/io/jfc/cursor/ACursorOperations.scala
+++ b/core/src/main/scala/io/jfc/cursor/ACursorOperations.scala
@@ -20,7 +20,7 @@ private[jfc] trait ACursorOperations extends GenericCursor[ACursor] { this: ACur
     ACursor(either.flatMap(c => f(c).either))
 
   def focus: Option[Json] = success.map(_.focus)
-  def undo: Option[Json] = success.map(_.undo)
+  def top: Option[Json] = success.map(_.top)
   def up: ACursor = withHCursor(_.up)
 
   def delete: ACursor = withHCursor(_.delete)

--- a/core/src/main/scala/io/jfc/cursor/CursorOperations.scala
+++ b/core/src/main/scala/io/jfc/cursor/CursorOperations.scala
@@ -13,7 +13,7 @@ private[jfc] trait CursorOperations extends GenericCursor[Cursor] { this: Cursor
   type Result = Option[Cursor]
   type M[x[_]] = Functor[x]
 
-  def undo: Json = {
+  def top: Json = {
     @tailrec
     def go(c: Cursor): Json = c match {
       case CJson(j) => j
@@ -46,8 +46,8 @@ private[jfc] trait CursorOperations extends GenericCursor[Cursor] { this: Cursor
   def lefts: Option[List[Json]] = None
   def rights: Option[List[Json]] = None
 
-  def fieldSet: Option[Set[String]] = focus.asObj.map(_.fieldSet)
-  def fields: Option[List[String]] = focus.asObj.map(_.fields)
+  def fieldSet: Option[Set[String]] = focus.asObject.map(_.fieldSet)
+  def fields: Option[List[String]] = focus.asObject.map(_.fields)
 
   def left: Option[Cursor] = None
   def right: Option[Cursor] = None
@@ -105,7 +105,7 @@ private[jfc] trait CursorOperations extends GenericCursor[Cursor] { this: Cursor
   def field(k: String): Option[Cursor] = None
 
   def downField(k: String): Option[Cursor] =
-    focus.asObj.flatMap(o => o(k).map(j => CObject(j, k, this, false, o)))
+    focus.asObject.flatMap(o => o(k).map(j => CObject(j, k, this, false, o)))
 
   def deleteGoLeft: Option[Cursor] = None
   def deleteGoRight: Option[Cursor] = None

--- a/core/src/main/scala/io/jfc/cursor/HCursorOperations.scala
+++ b/core/src/main/scala/io/jfc/cursor/HCursorOperations.scala
@@ -14,7 +14,7 @@ private[jfc] trait HCursorOperations extends GenericCursor[HCursor] { this: HCur
   type M[x[_]] = Functor[x]
 
   def focus: Json = cursor.focus
-  def undo: Json = cursor.undo
+  def top: Json = cursor.top
   def up: ACursor = history.acursorElement(cursor, _.up, CursorOpUp)
 
   def delete: ACursor = history.acursorElement(cursor, _.delete, CursorOpDeleteGoParent)

--- a/core/src/test/scala/io/jfc/CursorTests.scala
+++ b/core/src/test/scala/io/jfc/CursorTests.scala
@@ -5,21 +5,21 @@ import io.jfc.test.CursorSuite
 
 class CursorTests extends CursorSuite[Cursor] {
   def fromJson(j: Json): Cursor = Cursor(j)
-  def top(c: Cursor): Option[Json] = Some(c.undo)
+  def top(c: Cursor): Option[Json] = Some(c.top)
   def focus(c: Cursor): Option[Json] = Some(c.focus)
   def fromResult(result: Option[Cursor]): Option[Cursor] = result
 }
 
 class HCursorTests extends CursorSuite[HCursor] {
   def fromJson(j: Json): HCursor = Cursor(j).hcursor
-  def top(c: HCursor): Option[Json] = Some(c.undo)
+  def top(c: HCursor): Option[Json] = Some(c.top)
   def focus(c: HCursor): Option[Json] = Some(c.focus)
   def fromResult(result: ACursor): Option[HCursor] = result.success
 }
 
 class ACursorTests extends CursorSuite[ACursor] {
   def fromJson(j: Json): ACursor = Cursor(j).hcursor.acursor
-  def top(c: ACursor): Option[Json] = c.undo
+  def top(c: ACursor): Option[Json] = c.top
   def focus(c: ACursor): Option[Json] = c.focus
   def fromResult(result: ACursor): Option[ACursor] = result.success.map(_.acursor)
 }


### PR DESCRIPTION
This is a mix of things. I've added a new section to the docs, put some initial imports in the `core` REPL, renamed `undo` to `top` (since [I've always found the name kind of confusing](http://stackoverflow.com/q/20034646)), and added some methods to `Json`.