### PR TITLE
Fix #1: Rename toJson to asJson

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ defined class Qux
 scala> val foo: Foo = Qux(13, Some(14.0))
 foo: Foo = Qux(13,Some(14.0))
 
-scala> foo.toJson.noSpaces
+scala> foo.asJson.noSpaces
 res0: String = {"Qux":{"d":14.0,"i":13}}
 
-scala> decode[Foo](foo.toJson.spaces4)
+scala> decode[Foo](foo.asJson.spaces4)
 res1: cats.data.Xor[io.jfc.Error,Foo] = Right(Qux(13,Some(14.0)))
 ```
 

--- a/benchmark/src/main/scala/io/jfc/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/io/jfc/benchmark/Benchmark.scala
@@ -4,7 +4,6 @@ import argonaut.{ Json => JsonA, _ }, Argonaut._
 import io.jfc.{ Json => JsonJ }
 import io.jfc.auto._
 import io.jfc.jawn._
-import io.jfc.syntax._
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 
@@ -21,11 +20,14 @@ class ExampleData {
     ("b" * i) -> Foo("a" * i, i + 1.0 / i, i, i * 1000L, (0 to i).map(_ % 2 == 0).toList)
   }.toMap
 
-  val intsJ: JsonJ = ints.toJson
-  val intsA: JsonA = ints.asJson
+  @inline def encodeA[A](a: A)(implicit encode: EncodeJson[A]): JsonA = encode(a)
+  @inline def encodeJ[A](a: A)(implicit encode: Encode[A]): JsonJ = encode(a)
 
-  val foosJ: JsonJ = foos.toJson
-  val foosA: JsonA = foos.asJson
+  val intsJ: JsonJ = encodeJ(ints)
+  val intsA: JsonA = encodeA(ints)
+
+  val foosJ: JsonJ = encodeJ(foos)
+  val foosA: JsonA = encodeA(foos)
 
   val intsJson: String = intsJ.noSpaces
   val foosJson: String = foosJ.noSpaces
@@ -42,17 +44,18 @@ class ExampleData {
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
 class EncodingBenchmark extends ExampleData {
-  @Benchmark
-  def encodeIntsJ: JsonJ = ints.toJson
 
   @Benchmark
-  def encodeIntsA: JsonA = ints.asJson
+  def encodeIntsJ: JsonJ = encodeJ(ints)
 
   @Benchmark
-  def encodeFoosJ: JsonJ = foos.toJson
+  def encodeIntsA: JsonA = encodeA(ints)
 
   @Benchmark
-  def encodeFoosA: JsonA = foos.asJson
+  def encodeFoosJ: JsonJ = encodeJ(foos)
+
+  @Benchmark
+  def encodeFoosA: JsonA = encodeA(foos)
 }
 
 /**

--- a/benchmark/src/main/scala/io/jfc/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/io/jfc/benchmark/Benchmark.scala
@@ -1,7 +1,7 @@
 package io.jfc.benchmark
 
 import argonaut.{ Json => JsonA, _ }, Argonaut._
-import io.jfc.{ Json => JsonJ }
+import io.jfc.{ Json => JsonJ, Encode }
 import io.jfc.auto._
 import io.jfc.jawn._
 import java.util.concurrent.TimeUnit

--- a/core/src/main/scala/io/jfc/syntax/package.scala
+++ b/core/src/main/scala/io/jfc/syntax/package.scala
@@ -5,6 +5,6 @@ package io.jfc
  */
 package object syntax {
   implicit class EncodeOps[A](val a: A) extends AnyVal {
-    def toJson(implicit e: Encode[A]): Json = e(a)
+    def asJson(implicit e: Encode[A]): Json = e(a)
   }
 }

--- a/core/src/test/scala/io/jfc/SyntaxTests.scala
+++ b/core/src/test/scala/io/jfc/SyntaxTests.scala
@@ -6,10 +6,10 @@ import io.jfc.test.{ CodecTests, JfcSuite }
 import org.scalacheck.Prop.forAll
 
 class SyntaxTests extends JfcSuite {
-  test("EncodeOps.toJson") {
+  test("EncodeOps.asJson") {
     check {
       forAll { (s: String) =>
-        s.toJson === Json.string(s)
+        s.asJson === Json.string(s)
       }
     }
   }

--- a/core/src/test/scala/io/jfc/test/CursorSuite.scala
+++ b/core/src/test/scala/io/jfc/test/CursorSuite.scala
@@ -12,26 +12,26 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit eq: Eq[C]) extends Jf
   def fromResult(result: C#Result): Option[C]
 
   val j1: Json = Json.obj(
-    "a" -> (1 to 5).toList.toJson,
-    "b" -> Map("d" -> List(true, false, true)).toJson,
-    "c" -> Map("e" -> 100.1, "f" -> 200.2).toJson
+    "a" -> (1 to 5).toList.asJson,
+    "b" -> Map("d" -> List(true, false, true)).asJson,
+    "c" -> Map("e" -> 100.1, "f" -> 200.2).asJson
   )
 
   val j2: Json = Json.obj(
-    "a" -> (0 to 5).toList.toJson,
-    "b" -> Map("d" -> List(true, false, true)).toJson,
-    "c" -> Map("e" -> 100.1, "f" -> 200.2).toJson
+    "a" -> (0 to 5).toList.asJson,
+    "b" -> Map("d" -> List(true, false, true)).asJson,
+    "c" -> Map("e" -> 100.1, "f" -> 200.2).asJson
   )
 
   val j3: Json = Json.obj(
-    "a" -> (1 to 5).toList.toJson,
-    "b" -> 10.toJson,
-    "c" -> Map("e" -> 100.1, "f" -> 200.2).toJson
+    "a" -> (1 to 5).toList.asJson,
+    "b" -> 10.asJson,
+    "c" -> Map("e" -> 100.1, "f" -> 200.2).asJson
   )
 
   val j4: Json = Json.obj(
-    "a" -> (1 to 5).toList.toJson,
-    "c" -> Map("e" -> 100.1, "f" -> 200.2).toJson
+    "a" -> (1 to 5).toList.asJson,
+    "c" -> Map("e" -> 100.1, "f" -> 200.2).asJson
   )
 
   val cursor: C = fromJson(j1)
@@ -39,7 +39,7 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit eq: Eq[C]) extends Jf
   test("withFocus") {
     val result = fromResult(cursor.downField("a")).map(
     	_.withFocus(j =>
-    		j.asArray.fold(j)(a => Json.fromValues(0.toJson :: a))
+    		j.asArray.fold(j)(a => Json.fromValues(0.asJson :: a))
     	)
     )
     
@@ -47,7 +47,7 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit eq: Eq[C]) extends Jf
   }
 
   test("set") {
-    val result = fromResult(cursor.downField("b")).map(_.set(10.toJson))
+    val result = fromResult(cursor.downField("b")).map(_.set(10.asJson))
 
     assert(result.flatMap(top) === Some(j3))
   }
@@ -59,7 +59,7 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit eq: Eq[C]) extends Jf
       l <- a.lefts
     } yield l
 
-    assert(result === Some(List(3.toJson, 2.toJson, 1.toJson)))
+    assert(result === Some(List(3.asJson, 2.asJson, 1.asJson)))
   }
 
   test("rights") {
@@ -69,7 +69,7 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit eq: Eq[C]) extends Jf
       l <- a.rights
     } yield l
 
-    assert(result === Some(List(5.toJson)))
+    assert(result === Some(List(5.asJson)))
   }
 
   test("fieldSet") {
@@ -87,7 +87,7 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit eq: Eq[C]) extends Jf
       l <- fromResult(a.left)
     } yield l
 
-    assert(result.flatMap(focus) === Some(3.toJson))
+    assert(result.flatMap(focus) === Some(3.asJson))
   }
 
   test("invalid left") {
@@ -106,7 +106,7 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit eq: Eq[C]) extends Jf
       l <- fromResult(a.right)
     } yield l
 
-    assert(result.flatMap(focus) === Some(5.toJson))
+    assert(result.flatMap(focus) === Some(5.asJson))
   }
 
   test("invalid right") {


### PR DESCRIPTION
I went ahead and closed the first (#1) ticket in jfc!

Please, note that I had to refactor the benchamark a bit to workaround the fact that `asJson` is available in both libraries Argonaut and jfc.