### PR TITLE
Some efficiency improvements for jfc.

### DIFF
--- a/core/src/main/scala/io/jfc/JsonNumber.scala
+++ b/core/src/main/scala/io/jfc/JsonNumber.scala
@@ -155,28 +155,32 @@ sealed abstract class JsonNumber {
     case JsonDouble(n) => JsonDecimal(n.toString)
   }
 
-  override def hashCode: Int =
-    if (isReal) toJsonDecimal.normalized.hashCode
-    else toDouble.hashCode
-
-  override def equals(that: Any): Boolean = that match {
-    case (that: JsonNumber) =>
-      if (this.isReal && that.isReal) {
-        (this, that) match {
-          case (a @ JsonDecimal(_), b) => a.normalized == b.toJsonDecimal.normalized
-          case (a, b @ JsonDecimal(_)) => a.toJsonDecimal.normalized == b.normalized
-          case (JsonLong(x), JsonLong(y)) => x == y
-          case (JsonDouble(x), JsonLong(y)) => x == y
-          case (JsonLong(x), JsonDouble(y)) => y == x
-          case (JsonDouble(x), JsonDouble(y)) => x == y
-          case (a, b) => a.toBigDecimal == b.toBigDecimal
-        }
-      } else {
-        this.toDouble == that.toDouble
+  def ===(that: JsonNumber): Boolean =
+    if (this.isReal && that.isReal) {
+      (this, that) match {
+        case (a @ JsonDecimal(_), b) => a.normalized == b.toJsonDecimal.normalized
+        case (a, b @ JsonDecimal(_)) => a.toJsonDecimal.normalized == b.normalized
+        case (JsonLong(x), JsonLong(y)) => x == y
+        case (JsonDouble(x), JsonLong(y)) => x == y
+        case (JsonLong(x), JsonDouble(y)) => y == x
+        case (JsonDouble(x), JsonDouble(y)) => x == y
+        case (a, b) => a.toBigDecimal == b.toBigDecimal
       }
+    } else {
+      this.toDouble == that.toDouble
+    }
 
-    case _ => false
-  }
+  def =!=(that: JsonNumber): Boolean =
+    !(this === that)
+
+  override def hashCode: Int =
+    if (isReal) toJsonDecimal.normalized.hashCode else toDouble.hashCode
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case that: JsonNumber => this === that
+      case _ => false
+    }
 }
 
 /**

--- a/core/src/main/scala/io/jfc/JsonObject.scala
+++ b/core/src/main/scala/io/jfc/JsonObject.scala
@@ -95,6 +95,13 @@ sealed abstract class JsonObject {
    * Returns the number of associations.
    */
   def size: Int
+
+  def ===(that: JsonObject): Boolean =
+    this.toMap == that.toMap
+
+  def =!=(that: JsonObject): Boolean =
+    this.toMap != that.toMap
+
 }
 
 private[jfc] final case class JsonObjectInstance(
@@ -166,7 +173,7 @@ private[jfc] final case class JsonObjectInstance(
 
   override def equals(o: Any) =
     o match {
-      case JsonObjectInstance(otherMap, _) => fieldsMap == otherMap
+      case j: JsonObject => this === j
       case _ => false
     }
 

--- a/core/src/test/scala/io/jfc/test/CodecTests.scala
+++ b/core/src/test/scala/io/jfc/test/CodecTests.scala
@@ -33,7 +33,11 @@ trait CodecTests[A] extends Laws {
   def codec(implicit A: Arbitrary[A], eq: Eq[A]): RuleSet = new DefaultRuleSet(
     name = "codec",
     parent = None,
-    "roundTrip" -> Prop.forAll((a: A) => isEqToProp(laws.codecRoundTrip(a)))
+    "roundTrip" -> Prop.forAll { (a: A) =>
+      val result: IsEq[Xor[DecodeFailure, A]] = laws.codecRoundTrip(a)
+      if (result.lhs != result.rhs) println(result)
+      result
+    }
   )
 }
 

--- a/jawn/src/main/scala/io/jfc/jawn/JfcSupportParser.scala
+++ b/jawn/src/main/scala/io/jfc/jawn/JfcSupportParser.scala
@@ -1,17 +1,17 @@
 package io.jfc.jawn
 
-import io.jfc.Json
+import io.jfc.{ Json, JsonDecimal }
 import jawn.{ FContext, Facade, SupportParser }
 import scala.collection.mutable.ArrayBuffer
 
 object JfcSupportParser extends SupportParser[Json] {
   implicit val facade: Facade[Json] = new Facade[Json] {
-    def jnull(): Json = Json.empty
-    def jfalse(): Json = Json.bool(false)
-    def jtrue(): Json = Json.bool(true)
-    def jnum(s: String): Json = Json.numberOrNull(java.lang.Double.parseDouble(s))
-    def jint(s: String): Json = Json.long(java.lang.Long.parseLong(s))
-    def jstring(s: String): Json = Json.string(s)
+    def jnull(): Json = Json.Empty
+    def jfalse(): Json = Json.False
+    def jtrue(): Json = Json.True
+    def jnum(s: String): Json = Json.JNumber(JsonDecimal(s))
+    def jint(s: String): Json = Json.JNumber(JsonDecimal(s))
+    def jstring(s: String): Json = Json.JString(s)
 
     def singleContext(): FContext[Json] = new FContext[Json] {
       private[this] var value: Json = null


### PR DESCRIPTION
Here's a list of changes:

 1. Introduce typesafe === and =!= equality methods.
 2. Introduce static True and False values.
 3. Avoid reifying Eq[List[Json]] in each equality check.
 4. Avoid allocating a List[Json] for each array comparison.
 5. Switch parser from eager to lazy number parsing.
 6. Parse to static True/False values for less memory use.

Full disclosure: I haven't set up benchmarks for these yet.
I'm pretty sure these changes will help reduce the memory
footprint of using jfc, and speed up things like equality
tests, but obviously more testing is needed.